### PR TITLE
engine only updating state based on raft log

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
@@ -62,4 +63,12 @@ func (svc Service) GetId() string {
 
 func (dst Destination) GetId() string {
 	return dst.Name
+}
+
+func (svc Service) KernelKey() string {
+	return fmt.Sprintf("%s-%d-%s", svc.Host, svc.Port, svc.Protocol)
+}
+
+func (dst Destination) KernelKey() string {
+	return fmt.Sprintf("%s-%d", dst.Host, dst.Port)
 }

--- a/ipvs/ipvs_test.go
+++ b/ipvs/ipvs_test.go
@@ -1,6 +1,11 @@
 package ipvs_test
 
 import (
+	"fmt"
+	"sort"
+
+	gipvs "github.com/google/seesaw/ipvs"
+	"github.com/luizbafilho/fusis/api/types"
 	"github.com/luizbafilho/fusis/ipvs"
 
 	. "gopkg.in/check.v1"
@@ -9,13 +14,82 @@ import (
 func (s *IpvsSuite) TestNewIpvs(c *C) {
 	i, err := ipvs.New()
 	c.Assert(err, IsNil)
+	err = i.SyncState(s.state)
+	c.Assert(err, IsNil)
+}
 
-	err = i.AddService(ipvs.ToIpvsService(s.service))
-	c.Assert(err, IsNil)
+type serviceList []*gipvs.Service
 
-	// Verifies if a new instance flushes the ipvs table
-	i, err = ipvs.New()
+func (l serviceList) Len() int      { return len(l) }
+func (l serviceList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l serviceList) Less(i, j int) bool {
+	return fmt.Sprintf("%v", l[i].Address) < fmt.Sprintf("%v", l[j].Address)
+}
+
+func matchState(c *C, services1 []*gipvs.Service, state ipvs.State) {
+	for _, s := range services1 {
+		s.Flags = 0
+		s.Statistics = nil
+		for _, d := range s.Destinations {
+			d.Statistics = nil
+		}
+	}
+	stateServices := state.GetServices()
+	cmp := make([]*gipvs.Service, len(stateServices))
+	for i, s := range stateServices {
+		cmp[i] = ipvs.ToIpvsService(&s)
+	}
+	sort.Sort(serviceList(services1))
+	sort.Sort(serviceList(cmp))
+	c.Check(services1, DeepEquals, cmp)
+}
+
+func (s *IpvsSuite) TestIpvsSyncState(c *C) {
+	i, err := ipvs.New()
 	c.Assert(err, IsNil)
-	err = i.AddService(ipvs.ToIpvsService(s.service))
+	srv2 := &types.Service{
+		Name:         "test1",
+		Host:         "10.0.9.9",
+		Port:         80,
+		Scheduler:    "lc",
+		Protocol:     "tcp",
+		Destinations: []types.Destination{},
+	}
+	dst2 := &types.Destination{
+		Name:   "test1",
+		Host:   "192.168.9.9",
+		Port:   80,
+		Mode:   "nat",
+		Weight: 1,
+	}
+	s.state.AddService(s.service)
+	s.state.AddDestination(s.destination)
+	err = i.SyncState(s.state)
 	c.Assert(err, IsNil)
+	services, err := gipvs.GetServices()
+	c.Assert(err, IsNil)
+	matchState(c, services, s.state)
+	err = i.SyncState(s.state)
+	c.Assert(err, IsNil)
+	services, err = gipvs.GetServices()
+	c.Assert(err, IsNil)
+	matchState(c, services, s.state)
+	s.state.DeleteDestination(s.destination)
+	dst2.ServiceId = s.destination.ServiceId
+	s.state.AddDestination(dst2)
+	s.state.AddService(srv2)
+	dst2.Name = "testx"
+	dst2.ServiceId = srv2.GetId()
+	s.state.AddDestination(dst2)
+	err = i.SyncState(s.state)
+	c.Assert(err, IsNil)
+	services, err = gipvs.GetServices()
+	c.Assert(err, IsNil)
+	matchState(c, services, s.state)
+	s.state.DeleteService(srv2)
+	err = i.SyncState(s.state)
+	c.Assert(err, IsNil)
+	services, err = gipvs.GetServices()
+	c.Assert(err, IsNil)
+	matchState(c, services, s.state)
 }

--- a/ipvs/structs.go
+++ b/ipvs/structs.go
@@ -74,6 +74,9 @@ func destinationFlagsToString(flags gipvs.DestinationFlags) string {
 
 func ToIpvsService(s *types.Service) *gipvs.Service {
 	destinations := []*gipvs.Destination{}
+	for _, dest := range s.Destinations {
+		destinations = append(destinations, toIpvsDestination(&dest))
+	}
 
 	return &gipvs.Service{
 		Address:      net.ParseIP(s.Host),
@@ -84,7 +87,7 @@ func ToIpvsService(s *types.Service) *gipvs.Service {
 	}
 }
 
-func ToIpvsDestination(d *types.Destination) *gipvs.Destination {
+func toIpvsDestination(d *types.Destination) *gipvs.Destination {
 	return &gipvs.Destination{
 		Address: net.ParseIP(d.Host),
 		Port:    d.Port,
@@ -93,7 +96,7 @@ func ToIpvsDestination(d *types.Destination) *gipvs.Destination {
 	}
 }
 
-func GetServiceStats(s *gipvs.Service) *types.ServiceStats {
+func getServiceStats(s *gipvs.Service) *types.ServiceStats {
 
 	return &types.ServiceStats{
 		Connections: s.Statistics.Connections,
@@ -109,7 +112,7 @@ func GetServiceStats(s *gipvs.Service) *types.ServiceStats {
 	}
 }
 
-func GetDestinationStats(d *gipvs.Destination) *types.DestinationStats {
+func getDestinationStats(d *gipvs.Destination) *types.DestinationStats {
 
 	return &types.DestinationStats{
 		ActiveConns:   d.Statistics.ActiveConns,
@@ -120,9 +123,8 @@ func GetDestinationStats(d *gipvs.Destination) *types.DestinationStats {
 
 func FromService(s *gipvs.Service) types.Service {
 	destinations := []types.Destination{}
-
 	for _, dst := range s.Destinations {
-		destinations = append(destinations, FromDestination(dst))
+		destinations = append(destinations, fromDestination(dst))
 	}
 
 	return types.Service{
@@ -131,16 +133,16 @@ func FromService(s *gipvs.Service) types.Service {
 		Protocol:     ipProtoToString(s.Protocol),
 		Scheduler:    s.Scheduler,
 		Destinations: destinations,
-		Stats:        GetServiceStats(s),
+		Stats:        getServiceStats(s),
 	}
 }
 
-func FromDestination(d *gipvs.Destination) types.Destination {
+func fromDestination(d *gipvs.Destination) types.Destination {
 	return types.Destination{
 		Host:   d.Address.String(),
 		Port:   d.Port,
 		Weight: d.Weight,
 		Mode:   destinationFlagsToString(d.Flags),
-		Stats:  GetDestinationStats(d),
+		Stats:  getDestinationStats(d),
 	}
 }

--- a/ipvs/suite_test.go
+++ b/ipvs/suite_test.go
@@ -22,7 +22,6 @@ var _ = Suite(&IpvsSuite{})
 
 func (s *IpvsSuite) SetUpSuite(c *C) {
 	logrus.SetOutput(ioutil.Discard)
-
 	s.service = &types.Service{
 		Name:         "test",
 		Host:         "10.0.1.1",
@@ -43,7 +42,12 @@ func (s *IpvsSuite) SetUpSuite(c *C) {
 }
 
 func (s *IpvsSuite) SetUpTest(c *C) {
-	state := ipvs.NewFusisState()
+	s.state = ipvs.NewFusisState()
+}
 
-	s.state = state
+func (s *IpvsSuite) TearDownSuite(c *C) {
+	i, err := ipvs.New()
+	c.Assert(err, IsNil)
+	err = i.Flush()
+	c.Assert(err, IsNil)
 }

--- a/net/net.go
+++ b/net/net.go
@@ -67,6 +67,19 @@ func GetVips(iface string) ([]netlink.Addr, error) {
 	return netlink.AddrList(link, netlink.FAMILY_V4)
 }
 
+func GetFusisVipsIps(iface string) ([]string, error) {
+	addrs, err := GetVips(iface)
+	if err != nil {
+		return nil, err
+	}
+	addrs = addrs[1:]
+	ips := make([]string, len(addrs))
+	for i, addr := range addrs {
+		ips[i] = addr.IP.String()
+	}
+	return ips, nil
+}
+
 func GetIpByInterface(iface string) (string, error) {
 	link, err := netlink.LinkByName(iface)
 	if err != nil {

--- a/provider/none.go
+++ b/provider/none.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/luizbafilho/fusis/api/types"
 	"github.com/luizbafilho/fusis/config"
 	"github.com/luizbafilho/fusis/ipvs"
@@ -39,10 +42,39 @@ func (n None) ReleaseVIP(s types.Service) error {
 	return nil
 }
 
-func (n None) AssignVIP(s *types.Service) error {
-	return net.AddIp(s.Host+"/32", n.iface)
-}
-
-func (n None) UnassignVIP(s *types.Service) error {
-	return net.DelIp(s.Host+"/32", n.iface)
+func (n None) SyncVIPs(state ipvs.State) error {
+	oldVIPs, err := net.GetFusisVipsIps(n.iface)
+	if err != nil {
+		return err
+	}
+	newServices := state.GetServices()
+	toAddMap := make(map[string]struct{})
+	for _, s := range newServices {
+		toAddMap[s.Host] = struct{}{}
+	}
+	var toRemove []string
+	for _, ip := range oldVIPs {
+		if _, isPresent := toAddMap[ip]; isPresent {
+			delete(toAddMap, ip)
+		} else {
+			toRemove = append(toRemove, ip)
+		}
+	}
+	var errors []string
+	for ip := range toAddMap {
+		err := net.AddIp(ip+"/32", n.iface)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("error adding ip %s: %s", ip, err))
+		}
+	}
+	for _, ip := range toRemove {
+		err := net.DelIp(ip+"/32", n.iface)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("error deleting ip %s: %s", ip, err))
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("multiple errors: %s", strings.Join(errors, " | "))
+	}
+	return nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -13,8 +13,7 @@ var ErrProviderNotRegistered = errors.New("Provider not registered")
 type Provider interface {
 	AllocateVIP(s *types.Service, state ipvs.State) error
 	ReleaseVIP(s types.Service) error
-	AssignVIP(s *types.Service) error
-	UnassignVIP(s *types.Service) error
+	SyncVIPs(state ipvs.State) error
 }
 
 func New(config *config.BalancerConfig) (Provider, error) {


### PR DESCRIPTION
Further operations are always executed based on the current state. This
includes manipulating VIPs and ipvs state in kernel.

Changes are always made based on diffs between the current state in
memory and the real state committed to the machine's kernel. Rules are
then added, removed or updated as needed.

It's possible to improve this code even more in the future to avoid
unnecessary update calls to the ipvs stack.