### PR TITLE
Remove the --bootstrap flag to balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Now that you have IPVS and fusis installed, run the project:
 
 ``` bash
 # Remember, fusis binary is at $GOPATH/bin/fusis, add it to your $PATH
-sudo fusis balancer --bootstrap
+sudo fusis balancer
 ```
 You should see something like:
 `[GIN-debug] Listening and serving HTTP on :8000`


### PR DESCRIPTION
It was deleted in this commit: https://github.com/luizbafilho/fusis/commit/22cb87cd5ee68da4c8ecd0ac507daf8da3bece93